### PR TITLE
ensure docker-compose test tests current version of image (vs. latest)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ version: 2.1
 
 jobs:
    build:
-      machine: true
+      machine:
+          image: ubuntu-2004:202111-01
       steps:
          - checkout
          - run:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 
 test-compose:
 	echo "image=${image_repo}:${version}" > compose/.env-test
-	cd compose && docker-compose config && docker-compose --env-file .env-test up -d && \
+	cd compose && docker-compose --env-file .env-test config && docker-compose --env-file .env-test up -d && \
 	sleep 5 && docker-compose logs 2>&1 | grep "Starting Geth on Rinkeby" && \
 	docker-compose down && rm .env-test
 

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,10 @@ test:
 	docker build --target test --build-arg geth_version=$(version) --tag geth:test . && docker run --env-file test/test.env geth:test
 
 test-compose:
-	cd compose && docker-compose config && docker-compose up -d && \
+	echo "image=${image_repo}:${version}" > compose/.env-test
+	cd compose && docker-compose config && docker-compose --env-file .env-test up -d && \
 	sleep 5 && docker-compose logs 2>&1 | grep "Starting Geth on Rinkeby" && \
-	docker-compose down
+	docker-compose down && rm .env-test
 
 release:
 	docker build --target release --tag $(image_repo):$(version) --build-arg geth_version=$(version) .


### PR DESCRIPTION
* customize compose test image via custom .env file
* update circle-ci machine vm image to latest ubuntu-20.04 variant (contains up-to-date `docker-compose` bits) 