### PR TITLE
set compose host data dir to /var/tmp subpath and remove hardcoded metrics.addr var

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - "--config=${GETH_CONFIG_DIR:-/etc/geth}/config.toml"
       - "--http"
       - "--metrics"
-      - "--metrics.addr=${metrics_addr}"
     environment:
       GETH_CONFIG_DIR: ${GETH_CONFIG_DIR:-/etc/geth}
     env_file:
@@ -25,7 +24,7 @@ services:
       - ${ws_port:-8546}:8546
       - ${metrics_port:-6060}:6060
     volumes:
-      - "${host_data_dir:-/operations/ethereum/geth/data}:${data_dir:-/root/.ethereum}"
+      - "${host_data_dir:-/var/tmp/geth/data}:${data_dir:-/root/.ethereum}"
     networks:
       - ethereum
     restart: ${restart_policy:-unless-stopped}


### PR DESCRIPTION
- address host (data) dir inconsistency issue across existing compose + ansible infra (see [issue/operator#64](https://github.com/0x0I/operator/issues/64))
- allow `--metrics.addr` var to be set within config (vs. explicit setting as runtime CLI flag in compose setup)

`export CONFIG-Metrics-HTTP="0.0.0.0"` or adding the same to the default or a custom *.env* file, which results in the following config setting, will provide the same effect.
```
[Metrics]                                                                                                                                               
HTTP = "0.0.0.0"
```